### PR TITLE
Tuples as Arguments

### DIFF
--- a/src/Foreign/Pythas/FFIType.hs
+++ b/src/Foreign/Pythas/FFIType.hs
@@ -14,9 +14,8 @@ makeFFIType funcname ccompattypes = fec funcname ++ typeDef ++ functype
 
 createFFIType :: [HType] -> [HType]
 createFFIType ts =
-    let fromT = map fromFFIType i
-        toT   = toFFIType (any isIO $ map toFFIType' i) $ last ts
-        i     = init ts
+    let fromT = map fromFFIType $ init ts
+        toT   = toFFIType (any isIO fromT) $ last ts
     in  map stripIO fromT ++ [toT]
 
 finalizerExport :: String -> HType -> String

--- a/src/Foreign/Pythas/FFIType.hs
+++ b/src/Foreign/Pythas/FFIType.hs
@@ -53,7 +53,7 @@ ffiType ht = case ht of
     HIO ht'  -> "IO " ++ further ht'
     HCArray ht' -> "CArray " ++ further ht'
     HCList ht'  -> "CList " ++ further ht'
-    HTuple hts -> case length hts of
+    HCTuple hts -> case length hts of
                     2 -> "CTuple2 " ++ furthers hts
                     3 -> "CTuple3 " ++ furthers hts
                     4 -> "CTuple4 " ++ furthers hts

--- a/src/Foreign/Pythas/Finalizer.hs
+++ b/src/Foreign/Pythas/Finalizer.hs
@@ -50,21 +50,3 @@ freeTupleContents asts = let
             []   -> Nothing
             x:xs -> foldr (liftA2 Next) x xs
 
-freeTuple2 :: Maybe AST -> Maybe AST -> Maybe AST
-freeTuple2 a b = case (a,b) of
-    (Nothing, Nothing) -> Nothing
-    (Just fa, Just fb) -> Just $ Next fa fb
-    (fa, Nothing) -> fa
-    (_ , fb)      -> fb
-
-freeTuple3 :: Maybe AST -> Maybe AST -> Maybe AST -> Maybe AST
-freeTuple3 a b c = case (a,b,c) of
-    (Nothing, Nothing, Nothing) -> Nothing
-    (Just fa, Just fb, Just fc) -> Just $ Next fa $ Next fb fc
-    (Just fa, Just fb, Nothing) -> Just $ Next fa fb
-    (Just fa, Nothing, Just fc) -> Just $ Next fa fc
-    (Nothing, Just fb, Just fc) -> Just $ Next fb fc
-    (fa, Nothing, Nothing) -> fa
-    (_ , fb, Nothing)      -> fb
-    (_ , _ , fc)           -> fc
-

--- a/src/Foreign/Pythas/Finalizer.hs
+++ b/src/Foreign/Pythas/Finalizer.hs
@@ -34,7 +34,7 @@ freeTuple as hast = let
     inner = case as of
         [a,b]     -> freeTuple2 (f a varA) (f b varB)
         [a,b,c]   -> freeTuple3 (f a varA) (f b varB) $ f c varC
---        [a,b,c,d] -> freeTuple4 (f a varA) (f b varB) (f c varC) $ f d varD
+        [a,b,c,d] -> freeTuple4 (f a varA) (f b varB) (f c varC) $ f d varD
         _        -> Nothing
         where f t v = finalize t $ v t
     in case inner of

--- a/src/Foreign/Pythas/Finalizer.hs
+++ b/src/Foreign/Pythas/Finalizer.hs
@@ -1,5 +1,8 @@
 module Foreign.Pythas.Finalizer where
 
+import Control.Applicative(liftA2)
+import Data.Maybe (isJust)
+
 import Foreign.Pythas.HTypes (HType(..), stripIO)
 import Foreign.Pythas.AST (AST(..), map')
 import Foreign.Pythas.Utils (free', fromC, finalizerName, tuple, varA, varB, varC, varD)
@@ -31,18 +34,21 @@ freeArray ht hast = let
 
 freeTuple :: [HType] -> AST -> Maybe AST
 freeTuple as hast = let
-    inner = case as of
-        [a,b]     -> freeTuple2 (f a varA) (f b varB)
-        [a,b,c]   -> freeTuple3 (f a varA) (f b varB) $ f c varC
-        [a,b,c,d] -> freeTuple4 (f a varA) (f b varB) (f c varC) $ f d varD
-        _        -> Nothing
-        where f t v = finalize t $ v t
+    inner = freeTupleContents as
     in case inner of
         Just inner -> Next <$>
                       (Just $ Bind (fromC (HTuple as) hast) $ Lambda [tuple as] inner)
                       <*> free
         Nothing    -> free
     where free = free' (HTuple as) hast
+
+freeTupleContents :: [HType] -> Maybe AST
+freeTupleContents asts = let
+        finalizers = filter isJust $ zipWith f asts [varA, varB, varC, varD]
+            where f t v = finalize t $ v t
+        in case finalizers of
+            []   -> Nothing
+            x:xs -> foldr (liftA2 Next) x xs
 
 freeTuple2 :: Maybe AST -> Maybe AST -> Maybe AST
 freeTuple2 a b = case (a,b) of

--- a/src/Foreign/Pythas/Utils.hs
+++ b/src/Foreign/Pythas/Utils.hs
@@ -21,7 +21,7 @@ toFFIType' :: HType -> HType
 toFFIType' ht = case ht of
  HString   -> HIO $ HCWString
  HList x   -> HIO $ HCArray $ toFFIType'' x
- HTuple xs -> HIO $ HTuple $ map toFFIType'' xs
+ HTuple xs -> HIO $ HCTuple $ map toFFIType'' xs
  HFunc xs  -> undefined
  HInteger  -> HLLong
  HInt      -> HCInt

--- a/src/Foreign/Pythas/Utils.hs
+++ b/src/Foreign/Pythas/Utils.hs
@@ -33,10 +33,10 @@ toFFIType' ht = case ht of
 
 fromFFIType :: HType -> HType
 fromFFIType ht = case ht of
- HString    -> HCWString
- HList x    -> HCArray $ fromFFIType x
- HTuple [x] -> undefined
- HFunc [x]  -> undefined
+ HString    -> HIO $ HCWString
+ HList x    -> HIO $ HCArray $ fromFFIType x
+ HTuple xs  -> HIO $ HCTuple $ map fromFFIType xs
+ HFunc  xs  -> undefined
  HInteger   -> HLLong
  HInt       -> HCInt
  HBool      -> HCBool

--- a/src/Foreign/Pythas/Utils.hs
+++ b/src/Foreign/Pythas/Utils.hs
@@ -34,8 +34,8 @@ toFFIType' ht = case ht of
 fromFFIType :: HType -> HType
 fromFFIType ht = case ht of
  HString    -> HIO $ HCWString
- HList x    -> HIO $ HCArray $ fromFFIType x
- HTuple xs  -> HIO $ HCTuple $ map fromFFIType xs
+ HList x    -> HIO $ HCArray $ stripIO $ fromFFIType x
+ HTuple xs  -> HIO $ HCTuple $ map (stripIO . fromFFIType) xs
  HFunc  xs  -> undefined
  HInteger   -> HLLong
  HInt       -> HCInt

--- a/test/ParseUnitTests.hs
+++ b/test/ParseUnitTests.hs
@@ -56,6 +56,7 @@ nested = [
     , "f :: [[Integer]] -> (Double, String)"
     , "f :: Char -> [(Float, Word32)]"
     , "f :: Bool -> [String] -> ([CInt], [Int8])"
+    , "f :: ([String], Int) -> [Int]"
     ]
 
 nestedRes = map Right [
@@ -63,6 +64,7 @@ nestedRes = map Right [
     , stdTD [HList (HList HInteger), HTuple [HDouble, HString]]
     , stdTD [HChar, HList (HTuple [HFloat, HCUInt])]
     , stdTD [HBool, HList HString, HTuple [HList HCInt, HList HCChar]]
+    , stdTD [HTuple [HList HString, HInt], HList HInt]
     ]
 
 unsupported = [

--- a/test/golden/gold/tuple.golden
+++ b/test/golden/gold/tuple.golden
@@ -1,3 +1,5 @@
-tuple =  ( (return (Test.tuple)) >>=
+tuple a =  ( ( ( (peekTuple2 a) >>=
+     (\ ( a,  b) ->  (liftM2 ((,)) (return a) (peekCWString b)))) >>=
+     (\ a ->  (return (Test.tuple a)))) >>=
      (\ res ->  ( ( (\ ( a,  b) ->  (liftM2 ((,)) (return a) (newCWString b))) res) >>=
      (\ res ->  (newTuple2 res)))))

--- a/test/golden/gold/tupleWithListOfNestedTuples.golden
+++ b/test/golden/gold/tupleWithListOfNestedTuples.golden
@@ -1,6 +1,6 @@
-tupleWithListOfTuples a b =  ( ( (peekCWString a) >>=
-     (\ a ->  ( (peekCWString b) >>=
-     (\ b ->  (return (Test.tupleWithListOfTuples a b)))))) >>=
+tupleWithListOfTuples a =  ( ( ( (peekTuple2 a) >>=
+     (\ ( a,  b) ->  (liftM2 ((,)) (peekCWString a) (peekCWString b)))) >>=
+     (\ a ->  (return (Test.tupleWithListOfTuples a)))) >>=
      (\ res ->  ( ( (\ ( a,  b) ->  (liftM2 ((,)) ( (mapM (\ a ->  ( ( (\ ( a,  b) ->  (liftM2 ((,)) (newCWString a) (newCWString b))) a) >>=
      (\ a ->  (newTuple2 a)))) a) >>=
      (\ a ->  (newArray a))) ( (return (map (fromIntegral) b)) >>=

--- a/test/golden/input/tuple.golden
+++ b/test/golden/input/tuple.golden
@@ -1,3 +1,3 @@
-tuple :: (CInt, String)
-tuple = (1 :: CInt, "a")
+tuple :: (CInt, String) -> (CInt, String)
+tuple = id
 

--- a/test/golden/input/tupleWithListOfNestedTuples.golden
+++ b/test/golden/input/tupleWithListOfNestedTuples.golden
@@ -1,3 +1,3 @@
-tupleWithListOfTuples :: String -> String -> ([(String, String)],[Int])
-tupleWithListOfTuples a b = (take 63 $ repeat (a,b), [63])
+tupleWithListOfTuples :: (String, String) -> ([(String, String)],[Int])
+tupleWithListOfTuples t = (take 63 $ repeat t, [63])
 

--- a/test/golden/output/tuple.golden
+++ b/test/golden/output/tuple.golden
@@ -1,3 +1,5 @@
-tuple =  ( (return (Test.tuple)) >>=
+tuple a =  ( ( ( (peekTuple2 a) >>=
+     (\ ( a,  b) ->  (liftM2 ((,)) (return a) (peekCWString b)))) >>=
+     (\ a ->  (return (Test.tuple a)))) >>=
      (\ res ->  ( ( (\ ( a,  b) ->  (liftM2 ((,)) (return a) (newCWString b))) res) >>=
      (\ res ->  (newTuple2 res)))))

--- a/test/golden/output/tupleWithListOfNestedTuples.golden
+++ b/test/golden/output/tupleWithListOfNestedTuples.golden
@@ -1,6 +1,6 @@
-tupleWithListOfTuples a b =  ( ( (peekCWString a) >>=
-     (\ a ->  ( (peekCWString b) >>=
-     (\ b ->  (return (Test.tupleWithListOfTuples a b)))))) >>=
+tupleWithListOfTuples a =  ( ( ( (peekTuple2 a) >>=
+     (\ ( a,  b) ->  (liftM2 ((,)) (peekCWString a) (peekCWString b)))) >>=
+     (\ a ->  (return (Test.tupleWithListOfTuples a)))) >>=
      (\ res ->  ( ( (\ ( a,  b) ->  (liftM2 ((,)) ( (mapM (\ a ->  ( ( (\ ( a,  b) ->  (liftM2 ((,)) (newCWString a) (newCWString b))) a) >>=
      (\ a ->  (newTuple2 a)))) a) >>=
      (\ a ->  (newArray a))) ( (return (map (fromIntegral) b)) >>=


### PR DESCRIPTION
Tuples so far cannot be passed as arguments to Haskell functions translated with Pythas-FFI. This is confusing and inconsistent. This PR adds the capability of tuples as arguments as well as improving on the implementation of tuple wrapping.